### PR TITLE
Расширен сервис:

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -7,6 +7,11 @@ spec:
   selector:
     matchLabels:
       app: application-server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -14,6 +19,6 @@ spec:
     spec:
       containers:
         - name: docker-server
-          image: stanislavpoliakov/docker-server:latest
+          image: stanislavpoliakov/docker-server:1.0.0
           ports:
             - containerPort: 8000

--- a/src/main/kotlin/home/Application.kt
+++ b/src/main/kotlin/home/Application.kt
@@ -6,6 +6,9 @@ import home.plugins.configureRouting
 import home.plugins.configureSerialization
 import io.ktor.server.application.Application
 import home.plugins.*
+import home.probes.Probe
+
+val probe = Probe
 
 fun main(args: Array<String>): Unit =
     io.ktor.server.netty.EngineMain.main(args)
@@ -13,7 +16,7 @@ fun main(args: Array<String>): Unit =
 @Suppress("unused")
 fun Application.module() {
     configureAdministration()
-    configureSerialization()
+    configureSerialization(probe)
     configureHTTP()
     configureRouting()
 }

--- a/src/main/kotlin/home/plugins/Serialization.kt
+++ b/src/main/kotlin/home/plugins/Serialization.kt
@@ -1,19 +1,85 @@
 package home.plugins
 
+import home.probes.LivenessProbe
+import home.probes.Probe
+import home.probes.ProbeStatus
+import home.probes.ReadinessProbe
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.response.*
 import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.server.routing.*
 
-fun Application.configureSerialization() {
+fun Application.configureSerialization(probe: Probe) {
     install(ContentNegotiation) {
         json()
     }
+    val hostname = System.getenv()["HOSTNAME"] ?: "local machine"
     routing {
         get("/health/") {
-                call.respond(status = HttpStatusCode.OK, message = mapOf("status" to "OK"))
+            call.respond(status = HttpStatusCode.OK, message = mapOf("status" to "OK"))
             }
+
+        get("/check/") {
+            call.respond(status = HttpStatusCode.OK, message = "-> ALIVE from: $hostname")
+        }
+
+        post("/probe/liveness/") {
+            runCatching {
+                when (val probeStatus = call.receive<LivenessProbe>().liveness) {
+                    ProbeStatus.SUCCESS, ProbeStatus.FAILED -> {
+                        val statusCode = if (probe.liveness == probeStatus) {
+                            HttpStatusCode.NotModified
+                        } else {
+                            probe.liveness = probeStatus
+                            HttpStatusCode.Accepted
+                        }
+
+                        call.respond(status = statusCode, message = "success")
+                    }
+                }
+            }.getOrElse {
+                call.respond(status = HttpStatusCode.BadRequest, message = "failed")
+            }
+        }
+
+        get("/probe/liveness/") {
+            call.respond(status = HttpStatusCode.OK, message = "${probe.liveness}")
+        }
+
+        post("/probe/readiness/") {
+            runCatching {
+                when (val probeStatus = call.receive<ReadinessProbe>().readiness) {
+                    ProbeStatus.SUCCESS, ProbeStatus.FAILED -> {
+                        val statusCode = if (probe.readiness == probeStatus) {
+                            HttpStatusCode.NotModified
+                        } else {
+                            probe.readiness = probeStatus
+                            HttpStatusCode.Accepted
+                        }
+
+                        call.respond(status = statusCode, message = "success")
+                    }
+                }
+            }.getOrElse {
+                call.respond(status = HttpStatusCode.BadRequest, message = "failed")
+            }
+        }
+
+        get("/probe/readiness/") {
+            call.respond(status = HttpStatusCode.OK, message = "${probe.readiness}")
+        }
+
+        get("/probe/all/") {
+            call.respond(
+                status = HttpStatusCode.OK,
+                message = mapOf(
+                    "liveness" to "${probe.liveness}",
+                    "readiness" to "${probe.readiness}"
+                )
+            )
+        }
     }
 }

--- a/src/main/kotlin/home/probes/Probe.kt
+++ b/src/main/kotlin/home/probes/Probe.kt
@@ -1,0 +1,19 @@
+package home.probes
+
+import kotlinx.serialization.Serializable
+
+object Probe {
+    var liveness: ProbeStatus = ProbeStatus.FAILED
+    var readiness: ProbeStatus = ProbeStatus.FAILED
+}
+
+enum class ProbeStatus {
+    SUCCESS, FAILED
+}
+
+@Serializable
+data class LivenessProbe(val liveness: ProbeStatus)
+
+@Serializable
+data class ReadinessProbe(val readiness: ProbeStatus)
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,4 +5,4 @@ ktor:
     deployment:
         port: 8000
         shutdown:
-            url: "/shutdown"
+            url: "/shutdown/"


### PR DESCRIPTION
GET /check/ - присылает HOSTNAME для pod (или local machine) 
GET /probe/liveness - присылает статус liveness-пробы 
GET /probe/readiness - присылает статус readiness-пробы 
POST /probe/liveness - установка пробы SUCCESS/FAILED 
POST /probe/readiness - установка пробы SUCCESS/FAILED 
GET /probe/all - статус всех проб JSON

для k8s модифицирован deployment на версионированный docker-image и плавный RollingUpdate (maxSurge, maxUnavailable)